### PR TITLE
App target configs

### DIFF
--- a/Targets/Apps/AppTarget.xcconfig
+++ b/Targets/Apps/AppTarget.xcconfig
@@ -1,0 +1,16 @@
+//
+// AppTarget.xcconfig
+//
+// Copyright (c) 2016 Twitter. All rights reserved.
+//
+
+#include "../../Architectures.xcconfig"
+#include "../../BuildOptions.xcconfig"
+#include "../../CompilerFeatures.xcconfig"
+#include "../../CompilerWarnings.xcconfig"
+#include "../Target.xcconfig"
+
+GCC_DYNAMIC_NO_PIC = NO
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks
+PRODUCT_NAME = $(TARGET_NAME)
+SKIP_INSTALL = NO

--- a/Targets/Apps/OSX-App.xcconfig
+++ b/Targets/Apps/OSX-App.xcconfig
@@ -1,0 +1,13 @@
+//
+// OSX-App.xcconfig
+//
+// Copyright (c) 2016 Twitter. All rights reserved.
+//
+
+#include "AppTarget.xcconfig"
+
+ARCHS = $(ARCHS_STANDARD_32_64_BIT)
+CODE_SIGN_IDENTITY = -
+COMBINE_HIDPI_IMAGES = YES
+SDKROOT = macosx
+SUPPORTED_PLATFORMS = macosx

--- a/Targets/Apps/iOS-App.xcconfig
+++ b/Targets/Apps/iOS-App.xcconfig
@@ -1,0 +1,13 @@
+//
+// iOS-App.xcconfig
+//
+// Copyright (c) 2016 Twitter. All rights reserved.
+//
+
+#include "AppTarget.xcconfig"
+
+ARCHS = $(ARCHS_STANDARD)
+CODE_SIGN_IDENTITY = iPhone Developer
+SDKROOT = iphoneos
+SUPPORTED_PLATFORMS = iphonesimulator iphoneos
+TARGETED_DEVICE_FAMILY = 1,2

--- a/Targets/Apps/tvOS-App.xcconfig
+++ b/Targets/Apps/tvOS-App.xcconfig
@@ -1,0 +1,13 @@
+//
+// tvOS-App.xcconfig
+//
+// Copyright (c) 2016 Twitter. All rights reserved.
+//
+
+#include "AppTarget.xcconfig"
+
+ARCHS = $(ARCHS_STANDARD)
+CODE_SIGN_IDENTITY = iPhone Developer
+SDKROOT = appletvos
+SUPPORTED_PLATFORMS = appletvsimulator appletvos
+TARGETED_DEVICE_FAMILY = 3

--- a/Targets/Target.xcconfig
+++ b/Targets/Target.xcconfig
@@ -1,5 +1,5 @@
 //
-// Framework.xcconfig
+// Target.xcconfig
 //
 // Copyright (c) 2015 Twitter. All rights reserved.
 //


### PR DESCRIPTION
- add default xcconfigs for ios, osx and tvos app targets, that include a general AppTarget.xcconfig, which includes a few optional xcconfigs and Target.xcconfig
