### PR TITLE
update setting propagation for target xcconfigs

### DIFF
--- a/Targets/Apps/AppTarget.xcconfig
+++ b/Targets/Apps/AppTarget.xcconfig
@@ -4,10 +4,6 @@
 // Copyright (c) 2016 Twitter. All rights reserved.
 //
 
-#include "../../Architectures.xcconfig"
-#include "../../BuildOptions.xcconfig"
-#include "../../CompilerFeatures.xcconfig"
-#include "../../CompilerWarnings.xcconfig"
 #include "../Target.xcconfig"
 
 GCC_DYNAMIC_NO_PIC = NO

--- a/Targets/Framework.xcconfig
+++ b/Targets/Framework.xcconfig
@@ -4,6 +4,8 @@
 // Copyright (c) 2015 Twitter. All rights reserved.
 //
 
+#include "Target.xcconfig"
+
 DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
 
 DEFINES_MODULE = YES

--- a/Targets/StaticLibrary.xcconfig
+++ b/Targets/StaticLibrary.xcconfig
@@ -4,4 +4,6 @@
 // Copyright (c) 2015 Twitter. All rights reserved.
 //
 
+#include "Target.xcconfig"
+
 EXECUTABLE_PREFIX = lib

--- a/Targets/Target.xcconfig
+++ b/Targets/Target.xcconfig
@@ -4,6 +4,12 @@
 // Copyright (c) 2015 Twitter. All rights reserved.
 //
 
+#include "../vendor/xcconfig/Architectures.xcconfig"
+#include "../vendor/xcconfig/CodeSigning.xcconfig"
+#include "../vendor/xcconfig/CompilerFeatures.xcconfig"
+#include "../vendor/xcconfig/CompilerWarnings.xcconfig"
+#include "../vendor/xcconfig/PreprocessorDefinitions.xcconfig"
+
 DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
 
 ALWAYS_SEARCH_USER_PATHS = NO


### PR DESCRIPTION
- move Architectures, CodeSigning, CompilerFeatures, CompilerWarnings and
  PreprocessorDefinitions includes into Target, and remove those includes from
  AppTarget
- include Target in StaticLibrary and Framework
