### PR TITLE
Simplify app target and remove 32bit macOS

### DIFF
--- a/Targets/Apps/AppTarget.xcconfig
+++ b/Targets/Apps/AppTarget.xcconfig
@@ -6,5 +6,7 @@
 
 #include "../Target.xcconfig"
 
+ARCHS = $(ARCHS_STANDARD)
+
 GCC_DYNAMIC_NO_PIC = NO
 SKIP_INSTALL = NO

--- a/Targets/Apps/OSX-App.xcconfig
+++ b/Targets/Apps/OSX-App.xcconfig
@@ -6,7 +6,6 @@
 
 #include "AppTarget.xcconfig"
 
-ARCHS = $(ARCHS_STANDARD_32_64_BIT)
 CODE_SIGN_IDENTITY = -
 COMBINE_HIDPI_IMAGES = YES
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks

--- a/Targets/Apps/iOS-App.xcconfig
+++ b/Targets/Apps/iOS-App.xcconfig
@@ -6,7 +6,6 @@
 
 #include "AppTarget.xcconfig"
 
-ARCHS = $(ARCHS_STANDARD)
 CODE_SIGN_IDENTITY = iPhone Developer
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks
 SDKROOT = iphoneos

--- a/Targets/Apps/tvOS-App.xcconfig
+++ b/Targets/Apps/tvOS-App.xcconfig
@@ -6,7 +6,6 @@
 
 #include "AppTarget.xcconfig"
 
-ARCHS = $(ARCHS_STANDARD)
 CODE_SIGN_IDENTITY = iPhone Developer
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks
 SDKROOT = appletvos

--- a/Targets/Apps/watchOS-App.xcconfig
+++ b/Targets/Apps/watchOS-App.xcconfig
@@ -6,7 +6,6 @@
 
 #include "AppTarget.xcconfig"
 
-ARCHS = $(ARCHS_STANDARD)
 SDKROOT = watchos
 SUPPORTED_PLATFORMS = watchsimulator watchos
 SKIP_INSTALL = YES


### PR DESCRIPTION
Building a 32-bit app for macOS is a pretty edge-case thing. Very few 32-bit only machines shipped, and you have to forgo a ton of modern language features to keep compatibility.